### PR TITLE
Update postcode_lookup.R

### DIFF
--- a/R/postcode_lookup.R
+++ b/R/postcode_lookup.R
@@ -119,7 +119,7 @@ postcode_lookup <- function(postcode) {
     r <- content(r)
     pc_result <- r[["result"]]
     take_names <- setdiff(names(pc_result), "codes")
-    pc_codes <- as.data.frame(pc_result$codes, stringsAsFactors = FALSE)
+    pc_codes <- as.data.frame(do.call(cbind, pc_result$codes), stringsAsFactors = FALSE)
     colnames(pc_codes) <- paste0(names(pc_codes), "_code")
     pc_result[sapply(pc_result, is.null)] <- list(NA)
     pc_df <- cbind(as.data.frame(pc_result[take_names],


### PR DESCRIPTION
> postcode_lookup("DA2 7HT")
Error in (function (..., row.names = NULL, check.rows = FALSE, check.names = TRUE,  : 
  arguments imply differing number of rows: 1, 0
 
That’s because list element $nuts is NULL, which throws an error when converting to a data frame. Proposed change fixes the problem.