### PR TITLE
`bulk_postcode_lookup()` supports vector and/or `...` input

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Depends:
     R (>= 3.1)
 Imports:
     httr
-RoxygenNote: 7.1.2
+RoxygenNote: 7.3.1
 Suggests: knitr,
     dplyr,
     rmarkdown,

--- a/R/bulk_postcode_lookup.R
+++ b/R/bulk_postcode_lookup.R
@@ -8,7 +8,7 @@
 #' @param postcodes Accepts a list of postcodes. Accepts up to 100 postcodes.
 #' For only one postcode use \code{\link{postcode_lookup}}.
 #'
-#' @return A list of length one.
+#' @return A list
 #' @seealso \code{\link{postcode_lookup}} for documentation.
 #'
 #' @export
@@ -24,7 +24,7 @@
 #'
 bulk_postcode_lookup <- function(...) {
   dots <- unlist(c(...), recursive = TRUE)
-  postcodes <- list(postcodes = ...)
+  postcodes <- list(postcodes = dots)
   check_list_limit(postcodes)
   postcodes <- lapply(postcodes, URLencode)
   r <- POST("https://api.postcodes.io/postcodes",

--- a/R/bulk_postcode_lookup.R
+++ b/R/bulk_postcode_lookup.R
@@ -22,7 +22,9 @@
 #' bulk_postcode_lookup(list("PR3 0SG", "M45 6GN", "EX165BL"))
 #' }
 #'
-bulk_postcode_lookup <- function(postcodes) {
+bulk_postcode_lookup <- function(...) {
+  dots <- unlist(c(...), recursive = TRUE)
+  postcodes <- list(postcodes = ...)
   check_list_limit(postcodes)
   postcodes <- lapply(postcodes, URLencode)
   r <- POST("https://api.postcodes.io/postcodes",

--- a/R/bulk_postcode_lookup.R
+++ b/R/bulk_postcode_lookup.R
@@ -5,7 +5,7 @@
 #' @importFrom httr POST
 #' @importFrom utils URLencode
 #'
-#' @param postcodes Accepts a list of postcodes. Accepts up to 100 postcodes.
+#' @param ... One or more vectors containing postcodes to look up. Up to 100 postcodes are accepted.
 #' For only one postcode use \code{\link{postcode_lookup}}.
 #'
 #' @return A list
@@ -15,13 +15,11 @@
 #'
 #' @examples
 #' \donttest{
-#' pc_list <- list(
-#' postcodes = c("PR3 0SG", "M45 6GN", "EX165BL")) # spaces are ignored
-#' bulk_postcode_lookup(pc_list)
-#' # The function needs a list of length one. This won't work:
-#' bulk_postcode_lookup(list("PR3 0SG", "M45 6GN", "EX165BL"))
+#' ## Postcodes can be provided as individual arguments
+#' bulk_postcode_lookup("PR30SG", "M456GN", "EX165BL")
+#' ## Or as one or more vectors:
+#' bulk_postcode_lookup(c("PR30SG", "M456GN"), "EX165BL")
 #' }
-#'
 bulk_postcode_lookup <- function(...) {
   dots <- unlist(c(...), recursive = TRUE)
   postcodes <- list(postcodes = dots)
@@ -37,8 +35,8 @@ check_list_limit <- function(x) {
   if (!is.list(x))
     stop("Please provide a list with postcodes.")
   if (length(x) == 0)
-    stop("Please provide a list with more than one postcode")
+    stop("Please provide more than one postcode")
   count <- sum(sapply(x, length))
   if (count > 100)
-    stop("Please provide a list with less than 100 postcodes.")
+    stop("Please provide fewer than 100 postcodes.")
 }

--- a/man/bulk_postcode_lookup.Rd
+++ b/man/bulk_postcode_lookup.Rd
@@ -4,27 +4,25 @@
 \alias{bulk_postcode_lookup}
 \title{Bulk postcode lookup}
 \usage{
-bulk_postcode_lookup(postcodes)
+bulk_postcode_lookup(...)
 }
 \arguments{
-\item{postcodes}{Accepts a list of postcodes. Accepts up to 100 postcodes.
+\item{...}{One or more vectors containing postcodes to look up. Up to 100 postcodes are accepted.
 For only one postcode use \code{\link{postcode_lookup}}.}
 }
 \value{
-A list of length one.
+A list
 }
 \description{
 Returns a list of matching postcodes and respective available data.
 }
 \examples{
 \donttest{
-pc_list <- list(
-postcodes = c("PR3 0SG", "M45 6GN", "EX165BL")) # spaces are ignored
-bulk_postcode_lookup(pc_list)
-# The function needs a list of length one. This won't work:
-bulk_postcode_lookup(list("PR3 0SG", "M45 6GN", "EX165BL"))
+## Postcodes can be provided as individual arguments
+bulk_postcode_lookup("PR30SG", "M456GN", "EX165BL")
+## Or as one or more vectors:
+bulk_postcode_lookup(c("PR30SG", "M456GN"), "EX165BL")
 }
-
 }
 \seealso{
 \code{\link{postcode_lookup}} for documentation.

--- a/tests/testthat/test-bulk_postcode_lookup.R
+++ b/tests/testthat/test-bulk_postcode_lookup.R
@@ -16,3 +16,11 @@ test_that("bulk_postcode_lookup works as expected", {
   expect_error(bulk_postcode_lookup(pc_list))
   expect_that(lookup_results, is_a("list"))
 })
+
+test_that("bulk_postcode_lookup_accepts_multiple_vectors", {
+  # Don't run these tests on the CRAN build servers
+  skip_on_cran()
+
+  expect_no_error(bulk_postcode_lookup("PR30SG", "M456GN", "EX165BL"))
+  expect_no_error(bulk_postcode_lookup("PR30SG", c("M456GN", "EX165BL")))
+})


### PR DESCRIPTION
`bulk_postcode_lookup()` used to only work accept this syntax:

```r
bulk_postcode_lookup(list(postcodes = c("PR30SG", "M456GN", "EX165BL"))
```

But now it also supports this syntax:

```r
## Postcodes can be provided as individual arguments
bulk_postcode_lookup("PR30SG", "M456GN", "EX165BL")
## Or as one or more vectors:
bulk_postcode_lookup(c("PR30SG", "M456GN"), "EX165BL")
```

The main change is only a couple of lines:
```r
bulk_postcode_lookup <- function(...) {
  dots <- unlist(c(...), recursive = TRUE)
  postcodes <- list(postcodes = dots)
#...
}
```